### PR TITLE
fix: remove condition to check for doc-id in url

### DIFF
--- a/custom.vcl.tmpl
+++ b/custom.vcl.tmpl
@@ -490,7 +490,6 @@ sub vcl_fini {
 sub paywall_subroutine {
   if (req.http.host + req.url !~ "\.(gif|ico|jpg|jpeg|png|css|js|woff)"
       && req.url != "/"
-      && req.url ~ "-li.[0-9]*"
       && resp.http.X-Paid-Content == "true"
   ) {
       var.set_string("eMeterQuery", {"{ "X-TokenId" : ""} + "{{ getenv "E_METER_X_TOKEN" }}"


### PR DESCRIPTION
I think the following check is not needed.

It checks for a specific format of the article url, that has the ld-id at the end. In other projects, we don't have the `ld.` in the url, so it makes unnecessary complication that needs to be handled.

The special header that is added (via metadata) to "paid articles" should be enough for the distinction here.

It is up to the metering system afterwards to decide what to do with the content that is labeled as being metered.

@ipavleski I don't think that this should impact the metering rules configured on your project