### PR TITLE
fix: extend eMeterQuery string with TENANT and PaywallType

### DIFF
--- a/custom.vcl.tmpl
+++ b/custom.vcl.tmpl
@@ -517,6 +517,14 @@ sub paywall_subroutine {
         var.set_string("eMeterQuery", var.get_string("eMeterQuery") + {", "User-Agent" : ""} + req.http.User-Agent + {"""});
       }
 
+      if (resp.http.X-TENANT != "") {
+        var.set_string("eMeterQuery", var.get_string("eMeterQuery") + {", "TENANT" : ""} + resp.http.X-TENANT + {"""});
+      }
+
+      if (resp.http.X-Paywall-Type != "") {
+        var.set_string("eMeterQuery", var.get_string("eMeterQuery") + {", "PaywallType" : ""} + resp.http.X-Paywall-Type + {"""});
+      }
+
       var.set_string("eMeterQuery", var.get_string("eMeterQuery") + " }");
       curl.set_timeout(2000);
       curl.post("{{ getenv "E_METER_URL" }}", var.get_string("eMeterQuery"));


### PR DESCRIPTION
Include new params used by decisioning api.
* TENANT
* PaywallType
