### PR TITLE
fix: Provide bot verification by ip address

### DIFF
--- a/custom.vcl.tmpl
+++ b/custom.vcl.tmpl
@@ -500,11 +500,11 @@ sub vcl_fini {
 sub bot_verification {
   if (req.http.User-Agent ~ "(?i)googlebot" && resp.http.X-Paid-Content == "true") {
     curl.set_timeout(1000);
-    var.set_string("requestUrl", "{{ getenv "BOT_VERIFICATION" }}" + "?ip=");
+    var.set_string("botVerificationUrl", "{{ getenv "BOT_VERIFICATION" }}" + "?ip=");
     if (req.http.X-Real-IP != "") {
-      var.set_string("requestUrl", var.get_string("requestUrl") + req.http.X-Real-IP);
+      var.set_string("botVerificationUrl", var.get_string("botVerificationUrl") + req.http.X-Real-IP);
     }
-    curl.get(var.get_string("requestUrl"));
+    curl.get(var.get_string("botVerificationUrl"));
     if (curl.status() > 0) {
       set req.http.verified-bot = curl.header("X-Bot-Name");
     }


### PR DESCRIPTION
If verification URL (BOT_VERIFICATION) is provided, try to resolve bot by ip address ( reverse dns lookup https://developers.google.com/search/docs/advanced/crawling/verifying-googlebot).

Currently we are verifying bot by only checking the `User-Agent` of the request, but that can be easily spoofed and user can get free access of our paid content.
In order to truly verify if it is google we need to do that reverse dns check, and we do that only if paid content is requested and user agent contains `googlebot`

Since we don't use enterprise varnish we can't use out of the box feature that provides this functionality -> https://docs.varnish-software.com/varnish-cache-plus/vmods/resolver/#

This sub will only be called if `BOT_VERIFICATION` env var is present.