### PR TITLE
fix(paywall-layout): Parse pwlayout from eMeter as a cookie to resp

### DIFF
--- a/custom.vcl.tmpl
+++ b/custom.vcl.tmpl
@@ -572,6 +572,13 @@ sub paywall_subroutine {
         var.set_string("eMeterAllowAccess", curl.header("AllowAccess"));
         var.set_string("eMeterLocation", curl.header("Location"));
         if (var.get_string("eMeterAllowAccess") == "false" && var.get_string("eMeterLocation") != "") {
+          if (var.get_string("eMeterLocation") ~ "pwlayout=") {
+            if (resp.http.Set-Cookie) {
+              set resp.http.Set-Cookie = resp.http.Set-Cookie + var.get_string("eMeterLocation") + "; path=/;";
+            } else {
+              set resp.http.Set-Cookie = var.get_string("eMeterLocation") + "; path=/;";
+            }
+          }
           if (var.get_string("eMeterLocation") ~ "lid=true" && req.url !~ "(\?)lid=true") {
             set req.url = regsuball(req.url, "(\?)(.*)", "");
             return (synth(751, "eMeter redirection"));


### PR DESCRIPTION
The idea is to have information about layout in the client, and not backend.