### PR TITLE
fix: cookie based caching as a hook

### DIFF
--- a/custom.vcl.tmpl
+++ b/custom.vcl.tmpl
@@ -303,14 +303,7 @@ sub vcl_hash {
   # Cache based on url
   hash_data(req.url);
 
-  # homepage cache based on cookie category
-  if (req.url == "/" && req.http.Cookie) {
-    cookie.parse(req.http.Cookie);
-    cookie.keep("category");
-    if(cookie.get_string()) {
-      hash_data(cookie.get_string());
-    }
-  }
+  {{ getenv "VARNISH_HOOK_VCL_HASH_END" "" }}
 }
 
 sub custom_purge {


### PR DESCRIPTION
changing this implementation to be a hook rather than fixed code gives us more freedom to change it and enable it on other pages as well.