### PR TITLE
fix: add another cookie to keep

### DIFF
--- a/custom.vcl.tmpl
+++ b/custom.vcl.tmpl
@@ -270,7 +270,7 @@ sub vcl_recv {
 
   if (req.http.Cookie) {
     cookie.parse(req.http.Cookie);
-    cookie.keep("MPP-SessionId,sso-sessionId,AccessToken,category");
+    cookie.keep_re("^(MPP-SessionId$|sso-sessionId$|AccessToken$|category$|spid\.)");
     set req.http.Cookie = cookie.get_string();
   }
 


### PR DESCRIPTION
Issue: [NCA510FPAS-1670](https://jira.extranet.netcetera.biz/jira/browse/NCA510FPAS-1670)
Docs: https://varnish-cache.org/docs/trunk/reference/vmod_cookie.html#void-keep-re-regex-expression

## Description
  - In the mentioned issue, we need another cookie in the amp requests. The cookie name is not always the same, but always starts with `spid.`. For this purpose I have changed the `cookie.keep` into `cookie.keep_re` which makes the selection from a regex. I made sure that all previous cookies are still present with this logic, and also added the cookie I need.