### PR TITLE
fix: [NCA510FPAS-1766] correct if condition

### DIFF
--- a/custom.vcl.tmpl
+++ b/custom.vcl.tmpl
@@ -592,9 +592,9 @@ sub paywall_subroutine {
         var.set_string("eMeterQuery", var.get_string("eMeterQuery") + {", "PaywallType" : ""} + resp.http.X-Paywall-Type + {"""});
       }
 
-      if (req.http.CF-Connecting-IP != "") {
+      if (req.http.CF-Connecting-IP) {
         var.set_string("eMeterQuery", var.get_string("eMeterQuery") + {", "EndUserClientRealIp" : ""} + req.http.CF-Connecting-IP + {"""});
-      } else if (req.http.X-Real-IP != "") {
+      } else if (req.http.X-Real-IP) {
         var.set_string("eMeterQuery", var.get_string("eMeterQuery") + {", "EndUserClientRealIp" : ""} + req.http.X-Real-IP + {"""});
       }
 


### PR DESCRIPTION
Issue: [NCA510FPAS-1766](https://jira.extranet.netcetera.biz/jira/browse/NCA510FPAS-1766)

## Description
  - The 'if' condition for the cloudflare req header was confirming if the value was not an empty string, but if the value was `undefined`, then the condition was fulfilled and the first line of code was executed. This PR fixes that for the Cloudflare req header.

NOTE: There are a lot more conditions like this which need fixing, but we can't be sure whether we need to change them or not, because in some cases we might need to avoid empty string and not undefined. For the sake of this ticket, I have tested this req header only, but I have also created an improvement ticket for the rest of the cookies: https://jira.extranet.netcetera.biz/jira/browse/NCA510FPCC-34