### PR TITLE
fix(asc-drive): temporarily disable Drive integration

### DIFF
--- a/custom.vcl.tmpl
+++ b/custom.vcl.tmpl
@@ -500,7 +500,6 @@ sub vcl_synth {
           set resp.http.Location = "https://" + req.http.Host + req.url + "&" + var.get_string("eMeterLocation");
         }
         {{ if (getenv "DRIVE_API_URL") }}
-        set resp.http.Location = resp.http.Location + "&ueg=" + var.get_string("DriveEngagementGroup");
         if (var.get_string("DriveCorrelationId") != "") {
           if (resp.http.Set-Cookie) {
             set resp.http.Set-Cookie = resp.http.Set-Cookie + "DriveCorrelationId=" + var.get_string("DriveCorrelationId") + "; path=/;";
@@ -636,12 +635,11 @@ sub paywall_subroutine {
           {{ if (getenv "DRIVE_API_URL") }}
           if (var.get_string("eMeterLocation") ~ "pid=true") {
             call get_engagement_group_and_correlation_id;
-            if (req.url !~ "(\?)pid=true" || regsub(req.url, "^.*(\?|&)ueg=(.*)(&|$)", "\2") != var.get_string("DriveEngagementGroup")) {
+            if (var.get_string("eMeterLocation") ~ "pid=true" && req.url !~ "(\?)pid=true") {
               set req.url = regsuball(req.url, "(\?)(.*)", "");
               var.set_string("eMeterLocation", regsub(var.get_string("eMeterLocation"), "lid=true", ""));
-              return (synth(751, "eMeter redirection"));
-            }
-            return; # here is ok, both pid=true and correct ueg are set
+            return (synth(751, "eMeter redirection"));
+          }
           }
           {{ else }}
           if (var.get_string("eMeterLocation") ~ "pid=true" && req.url !~ "(\?)pid=true") {


### PR DESCRIPTION
basically disables the changes in [this pr](https://github.com/forward-distribution/dockerfile-varnish/pull/23) because the changes in [this pr](https://github.com/forward-distribution/dockerfile-varnish/pull/24) have to go to production, but there is a dependency between them. I'll bring the changes removed in this PR back to master soon.

## Description
  - Removed the `&ueg={drive_response_value}` from being appended as a parameter at the end of the url. That will be used to show different paywall layer based on its value (5-6 possible values), but we must not activate that yet, that will be done together with the client in November 2024.
  - Brought back the old validation of the url, where we check if the eSuite metering returned `?pid=true` and if we are actually on that url. The new validation also included checking for the `&ueg={val}` part, and that is removed.

**NOTE**: This change affects only ASC, and the condition for this logic to be executed is that `DRIVE_API_URL` must be present. The changes here, or any other change in the PR's mentioned above will not affect other clients in any way.