### PR TITLE
fix(asc-drive): [NCA510FPAS-1942] use correct host for drive api

### DIFF
--- a/custom.vcl.tmpl
+++ b/custom.vcl.tmpl
@@ -676,7 +676,7 @@ sub get_engagement_group_and_correlation_id {
   curl.header_add("Content-Type: application/json");
 
   # post to DRIVE_API_URL with body e.g.: {"portal":"wn.de","user_id":"<user_id>"}
-  curl.post("{{ getenv "DRIVE_API_URL" }}", "{" + {""portal":""} + req.http.Host + {"","user_id":""} + var.get_string("DriveUserId") + {"""} + "}");
+  curl.post("{{ getenv "DRIVE_API_URL" }}", "{" + {""portal":""} + regsub(req.http.Host, "www\.", "") + {"","user_id":""} + var.get_string("DriveUserId") + {"""} + "}");
 
   if (curl.status() != 200) {
     var.set_string("DriveEngagementGroup", "default");


### PR DESCRIPTION
as described in the comments in [NCA510FPAS-1942](https://jira.extranet.netcetera.biz/jira/browse/NCA510FPAS-1942), we are sending to Drive 'www.wn.de' as portal, while we should send just 'wn.de'. This PR fixes that.