### PR TITLE
fix(drive): [nca510fpas-1942] correct cookie exrtaction

### DIFF
--- a/custom.vcl.tmpl
+++ b/custom.vcl.tmpl
@@ -668,10 +668,16 @@ sub paywall_subroutine {
 sub get_engagement_group_and_correlation_id {
   # retrieve user_id from sso id cookie if exists (user logged in), otherwise from spid
   if (req.http.Cookie ~ "sso-sessionId=") {
-    var.set_string("DriveUserId", regsub(req.http.Cookie, "(^|;\s*)sso-sessionId=(.*?)(;.*|$)", "\2"));
-  } else {
+    var.set_string("DriveUserId", regsub(req.http.Cookie, "^(.*sso-sessionId=)(.*?)(;.*|$)", "\2"));
+    std.log("drive user id sso cookie: " + var.get_string("DriveUserId") + ", full cookie: " + req.http.Cookie);
+  } else if (req.http.Cookie ~ "spid\..{4}=") {
     # example: spid.d8a1=6e785887-ce8e-4ac1-969a-785fb4a349cd.1721393063.5.1722338888.1721740542.c5e01ee3-4035-448d-9293-a4a0caa1364a => user_id = "6e785887-ce8e-4ac1-969a-785fb4a349cd"
     var.set_string("DriveUserId", regsub(req.http.Cookie, "^(.*spid\..{4}=)(.*?)\..*", "\2"));
+    std.log("drive user id spid cookie: " + var.get_string("DriveUserId") + ", full cookie: " + req.http.Cookie);
+  } else {
+    std.log("drive user id: no user id found, full cookie: " + req.http.Cookie);
+    curl.free();
+    return;
   }
 
   curl.set_timeout(1000);


### PR DESCRIPTION
issue: [nca510fpas-1942](https://jira.extranet.netcetera.biz/jira/browse/NCA510FPAS-1942)

## description
  - updated the regex for extracting the cookie that we send to Drive

## more detailed info
The first priority is to send the value of `sso-sessionId` cookie to Drive. Regex subtraction in vcl works in a way that it has to match the full value and extract a certain group, but if we don't have a strict regex that will with certainty cover the full string and exactly match the wanted value in the correct group, it doesn't always work properly. That's why the regex was slightly modified in this commit.
Second priority is the `spid.xxxx` cookie. Here I have only added a condition before trying to match the value of that cookie, check if it exists. There are cases where it doesn't exist but the regex returns the whole string and the value ends up being incorrect. This change ensures that if no `spid.xxxx` cookie exists, nothing will be sent.

Finally, please note that the changes in this block are behind an env variable that specifically enables Drive. For projects without Drive, this won't have any impact and will never be triggered.