### PR TITLE
chore: backend fetch hook

### DIFF
--- a/custom.vcl.tmpl
+++ b/custom.vcl.tmpl
@@ -355,7 +355,7 @@ sub vcl_backend_response {
   if (bereq.uncacheable) { return (deliver); }
   set beresp.http.url = bereq.url;
 
-  # Enable ESI for pages that request i`t
+  # Enable ESI for pages that request it
   if (beresp.http.Surrogate-Control ~ "ESI/1.0") {
     set beresp.do_esi = true;
   }

--- a/custom.vcl.tmpl
+++ b/custom.vcl.tmpl
@@ -339,6 +339,9 @@ sub vcl_miss {
 }
 
 sub vcl_backend_fetch {
+
+   <%- config.hooks?.vclBackendResponse || '' %>
+
   if (bereq.retries > 0) {
     if (bereq.http.host == "error") { set bereq.backend = {{ if $IS_ERROR_PAGE_REMOTE }}backend_error{{ else }}delivery.backend(){{ end }}; }
     else { set bereq.backend = delivery.backend(); }
@@ -352,7 +355,7 @@ sub vcl_backend_response {
   if (bereq.uncacheable) { return (deliver); }
   set beresp.http.url = bereq.url;
 
-  # Enable ESI for pages that request it
+  # Enable ESI for pages that request i`t
   if (beresp.http.Surrogate-Control ~ "ESI/1.0") {
     set beresp.do_esi = true;
   }

--- a/custom.vcl.tmpl
+++ b/custom.vcl.tmpl
@@ -339,9 +339,6 @@ sub vcl_miss {
 }
 
 sub vcl_backend_fetch {
-
-   <%- config.hooks?.vclBackendResponse || '' %>
-
   if (bereq.retries > 0) {
     if (bereq.http.host == "error") { set bereq.backend = {{ if $IS_ERROR_PAGE_REMOTE }}backend_error{{ else }}delivery.backend(){{ end }}; }
     else { set bereq.backend = delivery.backend(); }
@@ -352,6 +349,9 @@ sub vcl_backend_fetch {
 # Handle the HTTP request coming from our backend
 # Called after the response headers has been successfully retrieved from the backend.
 sub vcl_backend_response {
+
+  <%- config.hooks?.vclBackendResponseStart || '' %>
+
   if (bereq.uncacheable) { return (deliver); }
   set beresp.http.url = bereq.url;
 


### PR DESCRIPTION
We want to be able to alter the vcl_backend_fetch subroutine in order to remove the cache-control header from the server. This will allow us to create a varnish able to cache content from the server. This PR adds a hook at the beginning of the subroutine which allows us to inject logic at the start. 