### PR TITLE
Revert "fix(asc): remove drive ueg integration"

### DIFF
--- a/custom.vcl.tmpl
+++ b/custom.vcl.tmpl
@@ -519,6 +519,7 @@ sub vcl_synth {
           set resp.http.Location = "https://" + req.http.Host + req.url + "&" + var.get_string("eMeterLocation");
         }
         {{ if (getenv "DRIVE_API_URL") }}
+        set resp.http.Location = resp.http.Location + "&ueg=" + var.get_string("DriveEngagementGroup");
         if (var.get_string("DriveCorrelationId") != "") {
           if (resp.http.Set-Cookie) {
             set resp.http.Set-Cookie = resp.http.Set-Cookie + "DriveCorrelationId=" + var.get_string("DriveCorrelationId") + "; path=/;";
@@ -654,11 +655,12 @@ sub paywall_subroutine {
           {{ if (getenv "DRIVE_API_URL") }}
           if (var.get_string("eMeterLocation") ~ "pid=true") {
             call get_engagement_group_and_correlation_id;
-            if (var.get_string("eMeterLocation") ~ "pid=true" && req.url !~ "(\?)pid=true") {
+            if (req.url !~ "(\?)pid=true" || regsub(req.url, "^.*(\?|&)ueg=(.*)(&|$)", "\2") != var.get_string("DriveEngagementGroup")) {
               set req.url = regsuball(req.url, "(\?)(.*)", "");
               var.set_string("eMeterLocation", regsub(var.get_string("eMeterLocation"), "lid=true", ""));
               return (synth(751, "eMeter redirection"));
             }
+            return; # here is ok, both pid=true and correct ueg are set
           }
           {{ else }}
           if (var.get_string("eMeterLocation") ~ "pid=true" && req.url !~ "(\?)pid=true") {


### PR DESCRIPTION
Reverts forward-distribution/dockerfile-varnish#31

Bringing this back because it was requested by ASC. It doesn't impact other clients, at least clients which don't have DRIVE_API_URL defined (which only ASC has defined as of now).

Ticket: https://jira.extranet.netcetera.biz/jira/browse/NCA510FPAS-2210