### PR TITLE
fix(drive): [nca510fpas-2210] infinite redirect caused by drive

### DIFF
--- a/custom.vcl.tmpl
+++ b/custom.vcl.tmpl
@@ -695,6 +695,8 @@ sub get_engagement_group_and_correlation_id {
     std.log("drive user id spid cookie: " + var.get_string("DriveUserId") + ", full cookie: " + req.http.Cookie);
   } else {
     std.log("drive user id: no user id found, full cookie: " + req.http.Cookie);
+    var.set_string("DriveEngagementGroup", "default");
+    var.set_string("DriveCorrelationId", "");
     curl.free();
     return;
   }


### PR DESCRIPTION
issue: [nca510fpas-2210](https://jira.extranet.netcetera.biz/jira/browse/NCA510FPAS-2210)

## description
  - if no engagement group and correlation id was set, then the result was infinite redirect. Setting them up to 'default' and empty string respectively fixes that issue. 
  - please note that this change and the whole code block only applies if DRIVE_API_URL env variable is set, meaning that Drive tracking is enabled. Otherwise, it has no impact.